### PR TITLE
feat: set PSD Bank as top bank

### DIFF
--- a/lib/schemas/banks.schema.json
+++ b/lib/schemas/banks.schema.json
@@ -13884,7 +13884,7 @@
       "$oid": "65fb2564429176a59c86edf7"
     },
     "name": "PSD Bank",
-    "isTop": false,
+    "isTop": true,
     "logoUrl": "https://flizimages.s3.eu-central-1.amazonaws.com/bank-logos/psd.png",
     "group": "psd",
     "isInstant": true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flizpay-de/banks",
   "private": false,
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "files": [
     "dist",


### PR DESCRIPTION
Set PSD Bank as top bank

- PSD Bank does not have fields and is not being no credentials banks (as Revolut, N26 etc.)