### PR TITLE
feat: add Credentials Tutorial data

### DIFF
--- a/lib/banks.service.ts
+++ b/lib/banks.service.ts
@@ -5,7 +5,9 @@ import type {
   BankFields,
   BankFieldsSchemaType,
   BankSchemaType,
+  BankTutorial,
 } from "@/lib/types";
+import { BANK_CREDENTIALS_TUTORIAL } from "./main";
 
 /**
  * Service to handle bank-related operations.
@@ -134,6 +136,35 @@ export class BanksService {
   public static getId(object: BankSchemaType | BankFieldsSchemaType): string {
     return object._id.$oid;
   }
+
+  /**
+   * Returns the bank credentials tutorial for the specified locale and tutorial key.
+   * @param locale The locale to get the tutorial for.
+   * @param tutorialKey Either the bank id or the bank group.
+   * @returns The bank credentials tutorial for the specified locale and tutorial key
+   */
+  public static getBankCredentialsTutorial(
+    locale: keyof typeof BANK_CREDENTIALS_TUTORIAL,
+    tutorialKey: string
+  ): BankTutorial {
+    const map = BANK_CREDENTIALS_TUTORIAL[locale] as Record<
+      string,
+      BankTutorial
+    >;
+
+    return map[tutorialKey];
+  }
+
+  /**
+   * Checks if a bank has a credentials tutorial for the specified locale and tutorial key.
+   * @param locale The locale to check.
+   * @param tutorialKey Either the bank id or the bank group.
+   * @returns True if the bank has a credentials tutorial for the specified locale and tutorial key, false otherwise.
+   */
+  public static bankHasCredentialsTutorial = (
+    locale: keyof typeof BANK_CREDENTIALS_TUTORIAL,
+    tutorialKey: string
+  ): boolean => !!BanksService.getBankCredentialsTutorial(locale, tutorialKey);
 
   /**
    * Returns the bank ID from a BankFieldsSchemaType object.

--- a/lib/locales/de/bank-credentials-tutorial.json
+++ b/lib/locales/de/bank-credentials-tutorial.json
@@ -1,0 +1,193 @@
+{
+  "sparkasse": {
+    "bankName": "Sparkasse",
+    "header": {
+      "login": "Anmeldename",
+      "password": "PIN / Passwort"
+    },
+    "step": {
+      "login": {
+        "item": {
+          "1": "Öffne deine Sparkassen App.",
+          "2": "Gehe zu <b>Profil > Einstellungen > Kontozugangsdaten verwalten</b>.",
+          "3": "Wähle dein Konto aus und du siehst deinen Anmeldenamen. "
+        },
+        "listStyle": "decimal",
+        "button": "Weiter"
+      },
+      "password": {
+        "item": {
+          "1": "Verwende deine <b>Online-Banking-PIN.</b> Das ist die PIN, die du auch zum Login in dein Online-Banking in einem Browser nutzt.",
+          "2": "Hast du die PIN vergessen? Du kannst eine neuen PIN einstellen, indem du in deiner Sparkassen App hier klickst <b>Profil > Einstellungen > Freigabeverwaltung > Online-Banking PIN</b>",
+          "3": "Beachte, dass es sich weder um das <i>App-Passwort</i> noch um das <i>TAN-App-Passwort</i> handelt."
+        },
+        "listStyle": "disc",
+        "button": "Fertig"
+      }
+    }
+  },
+  "volksbank": {
+    "bankName": "Volksbank",
+    "header": {
+      "alias": "VR-NetKey/Alias",
+      "pin": "PIN"
+    },
+    "step": {
+      "alias": {
+        "item": {
+          "1": "Du hast von deiner Bank per <b>Brief einen VR-NetKey</b> erhalten <i>oder</i> du hast <b>selbst einen Alias vergebenselbst</b>, z.B. deine Email oder einen Namen.",
+          "2": "In deinen Bank Apps, findest du deinen VR-NetKey leider nicht."
+        },
+        "listStyle": "disc",
+        "button": "Weiter"
+      },
+      "pin": {
+        "item": {
+          "1": "Verwende die PIN, die du auch zum <b>Login in dein Online-Banking in einem Browser</b> nutzt.",
+          "2": "<b>Hast du die PIN vergessen?</b> Zusammen mit deiner TAN App (SecureGo plus) kannst du z.B. bei der Berliner Volksbank hier eine neue PIN vergeben: <span>https://www.berliner-volksbank.de/service/pin-vergessen.html</span>"
+        },
+        "listStyle": "disc",
+        "button": "Fertig"
+      }
+    }
+  },
+  "65fb2564429176a59c86e932": {
+    "bankName": "Commerzbank",
+    "header": {
+      "name": "Name/Nummer",
+      "pin": "PIN/Passwort"
+    },
+    "step": {
+      "name": {
+        "item": {
+          "1": "Öffne deine Commerzbank-App.",
+          "2": "Klicke unten im Menü auf <b>Profil</b>.",
+          "3": "Dort steht deine <b>Teilnehmernummer</b> ganz oben auf dem Bildschirm."
+        },
+        "listStyle": "decimal",
+        "extra": "Deinen Benutzernamen hast du selber vergeben. Du benötigst ihn aber nicht, wenn du deine Teilnehmernummer kennst.",
+        "extraStyle": "list-disc pt-4",
+        "extraPosition": "bottom",
+        "button": "Weiter"
+      },
+      "pin": {
+        "item": {
+          "1": "Verwende die PIN bzw. das Passwort, das du auch für den <b>Login in dein Online-Banking</b> im Browser oder in der Commerzbank-App nutzt.",
+          "2": "<b>Hast du die PIN oder das Passwort vergessen?</b> In der Commerzbank-App kannst du unter Profil > Digital Banking PIN eine neue PIN festlegen."
+        },
+        "listStyle": "disc",
+        "button": "Fertig"
+      }
+    }
+  },
+  "65fb2564429176a59c86e933": {
+    "bankName": "Deutsche Bank",
+    "header": {
+      "branch": "Filialnummer",
+      "accNumber": "Kontonummer"
+    },
+    "step": {
+      "branch": {
+        "item": {
+          "1": "Voreingetragen auf dem <b>Login-Bildschirm deiner Deutsche-Bank-App</b>.",
+          "2": "Hinten auf deiner Deutsche-Bank-Karte (<b>Debitkarte</b>).",
+          "3": "In der Deutsche-Bank-App im <b>Menü Icon oben rechts (drei Striche) > IBAN und BIC > die ersten drei Stellen deiner BLZ</b>"
+        },
+        "listStyle": "disc",
+        "extra": "Deine dreistellige Filialnummer findest du an einer der folgenden Stellen:",
+        "extraStyle": "list-none",
+        "extraPosition": "top",
+        "button": "Weiter"
+      },
+      "accNumber": {
+        "item": {
+          "1": "Voreingetragen auf dem <b>Login-Bildschirm deiner Deutsche-Bank-App</b>.",
+          "2": "Hinten auf deiner Deutsche-Bank-Karte (<b>Debitkarte</b>).",
+          "3": "In der Deutsche-Bank-App im <b>Menü oben rechts (drei Striche) > IBAN und BIC > Konto</b> (ohne die letzten zwei Ziffern)."
+        },
+        "listStyle": "disc",
+        "extra": "Deine 7-stellige Kontonummer findest du an einer der folgenden Stellen:",
+        "extraPosition": "top",
+        "button": "Fertig"
+      }
+    }
+  },
+  "666816b7941909eeadd917b3": {
+    "bankName": "C24",
+    "header": {
+      "mobileNumber": "Handynummer",
+      "pin": "PIN"
+    },
+    "step": {
+      "mobileNumber": {
+        "item": {
+          "1": "Wir hoffen, du findest deine Handynummer ohne unsere Hilfe."
+        },
+        "listStyle": "none",
+        "button": "Weiter"
+      },
+      "pin": {
+        "item": {
+          "1": "Deine PIN besteht aus vier Ziffern, die du auch zum <b>Login für deine C24-App</b> nutzt.",
+          "2": "<b>Hast du die PIN vergessen?</b> In der C24-App kannst du die PIN hier ändern: Profil (Icon oben links) > Sicherheit & Datenschutz > PIN ändern."
+        },
+        "listStyle": "disc",
+        "button": "Fertig"
+      }
+    }
+  },
+  "65fb2564429176a59c86e97f": {
+    "bankName": "TARGOBANK",
+    "header": {
+      "userId": "Benutzername",
+      "password": "Passwort"
+    },
+    "step": {
+      "userId": {
+        "item": {
+          "1": "Dein Benutzername ist identisch mit dem für den <b>Login in dein Online-Banking</b>.",
+          "2": "Falls du deinen <b>Benutzernamen vergessen</b> hast, kannst du ihn dir hier anzeigen lassen: <span>https://www.targobank.de/de/user/administration/UA_ForPassPriCusCurAcc.aspx</span>",
+          "3": "Falls du nur eine Kreditkarte der TARGOBANK hast, folge diesem Link: <span>https://www.targobank.de/de/user/administration/UA_ForPassPriCusCreCar.aspx</span>"
+        },
+        "listStyle": "disc",
+        "button": "Weiter"
+      },
+      "password": {
+        "item": {
+          "1": "Verwende dasselbe Passwort, das du auch für den <b>Login in dein Online-Banking</b> im Browser nutzt.",
+          "2": "Es ist <u>nicht</u> dein <i>easyTAN-Freigabecode</i>.",
+          "3": "<b>Hast du dein Passwort vergessen?</b> Hier kannst du ein neues festlegen: <span>https://www.targobank.de/de/user/administration/UA_ForPassPriCusCurAcc.aspx</span>",
+          "4": "Falls du nur eine Kreditkarte der TARGOBANK hast, folge diesem Link: <span>https://www.targobank.de/de/user/administration/UA_ForPassPriCusCreCar.aspx</span>"
+        },
+        "listStyle": "disc",
+        "button": "Fertig"
+      }
+    }
+  },
+  "65fb2564429176a59c86e9a0": {
+    "bankName": "DKB",
+    "header": {
+      "login": "Anmeldename",
+      "password": "Passwort"
+    },
+    "step": {
+      "login": {
+        "item": {
+          "1": "Hier kannst du dir deinen <b>Anmeldenamen per Email zuschicken lassen</b>: <span>https://banking.dkb.de/forgot-username</span> ",
+          "2": "Falls du deinen Anmeldenamen nicht selbst gewählt hast, setzt er sich meist aus den <b>letzten 10 Stellen deiner IBAN</b> (=Kontonummer) <b>und einem Zusatz</b> (meist  _p oder _c) zusammen. Zum Beispiel: 1234567890_p.",
+          "3": "Deine IBAN findest du z.B. auf der Rückseite deiner Debitkarte."
+        },
+        "listStyle": "disc",
+        "button": "Weiter"
+      },
+      "password": {
+        "item": {
+          "1": "Verwende dein <b>Online-Banking-Passwort</b>. Das ist das Passwort, das du auch zum Login in dein Online-Banking in einem Browser oder der DKB-App nutzt.",
+          "2": "<b>Hast du die PIN vergessen?</b> Du kannst ein neues Passwort einstellen, indem du in deiner DKB-App hier klickst: Profil > App-Einstellungen > Passwort ändern."
+        },
+        "listStyle": "disc",
+        "button": "Fertig"
+      }
+    }
+  }
+}

--- a/lib/locales/en/bank-credentials-tutorial.json
+++ b/lib/locales/en/bank-credentials-tutorial.json
@@ -1,0 +1,194 @@
+{
+  "sparkasse": {
+    "bankName": "Sparkasse",
+    "header": {
+      "login": "Login Name",
+      "password": "PIN / Password"
+    },
+    "step": {
+      "login": {
+        "item": {
+          "1": "Open your Sparkasse App.",
+          "2": "Go to <b>Profile > Settings > Manage Account Access</b>.",
+          "3": "Select account and view your login name."
+        },
+        "listStyle": "decimal",
+        "button": "Next"
+      },
+      "password": {
+        "item": {
+          "1": "Use your so called <b>Online Banking PIN</b>, which you would use to login to your <b>Sparkasse Online Banking</b> in a browser.",
+          "2": "Can’t remember at all? To set a new PIN, open your Sparkasse App, go to <b>Profile > Settings > Authorization management > Online-Banking PIN</b>",
+          "3": "Note that it is <u><i>not necessarily</i></u> the same as the app or the TAN app password."
+        },
+        "listStyle": "disc",
+        "button": "Done"
+      }
+    }
+  },
+  "volksbank": {
+    "bankName": "Volksbank",
+    "header": {
+      "alias": "VR-NetKey/Alias",
+      "pin": "PIN"
+    },
+    "step": {
+      "alias": {
+        "item": {
+          "1": "You received a <b>VR-NetKey from your bank by mail</b>, or you <b>may have set up an alias yourself</b> — for example, your email address or a chosen name.",
+          "2": "Unfortunately, your VR-NetKey is not visible in your banking apps."
+        },
+        "listStyle": "disc",
+        "button": "Next"
+      },
+      "pin": {
+        "item": {
+          "1": "Use the same PIN you use to <b>log in to your online banking in a browser</b>.",
+          "2": "<b>Forgot your PIN?</b> You can set a new PIN using your TAN app (SecureGo plus). Here is an example from Berliner Volksbank: <span>https://www.berliner-volksbank.de/service/pin-vergessen.html</span>"
+        },
+        "listStyle": "disc",
+        "button": "Done"
+      }
+    }
+  },
+  "65fb2564429176a59c86e932": {
+    "bankName": "Commerzbank",
+    "header": {
+      "name": "Name/Number",
+      "pin": "PIN/Password"
+    },
+    "step": {
+      "name": {
+        "item": {
+          "1": "Open your Commerzbank app.",
+          "2": "Tap on <b>Profile</b> in the menu at the bottom.",
+          "3": "Your <b>participant number</b> is shown at the top of the screen."
+        },
+        "listStyle": "decimal",
+        "extra": "You chose your username yourself, but you don’t need it as long as you know your participant number.",
+        "extraStyle": "list-disc pt-4",
+        "extraPosition": "bottom",
+        "button": "Next"
+      },
+      "pin": {
+        "item": {
+          "1": "Use the PIN or password you use to <b>log in to your online banking</b> via browser or the Commerzbank app.",
+          "2": "<b>Forgot your PIN or password?</b> You can set a new PIN in the Commerzbank app under Profile > Digital Banking PIN."
+        },
+        "listStyle": "disc",
+        "button": "Done"
+      }
+    }
+  },
+  "65fb2564429176a59c86e933": {
+    "bankName": "Deutsche Bank",
+    "header": {
+      "branch": "Branch",
+      "accNumber": "Account Number"
+    },
+    "step": {
+      "branch": {
+        "item": {
+          "1": "Pre-filled on the <b>login screen of your Deutsche Bank app</b>.",
+          "2": "On the back of your <b>Deutsche Bank card</b> (debit card).",
+          "3": "In the Deutsche Bank app: tap the menu icon (three lines) in the <b>top right > IBAN and BIC > the first three digits of your bank code (BCN)</b>."
+        },
+        "listStyle": "disc",
+        "extra": "You can find your three-digit branch number in one of the following places:",
+        "extraStyle": "list-none",
+        "extraPosition": "top",
+        "button": "Next"
+      },
+      "accNumber": {
+        "item": {
+          "1": "Pre-filled on the <b>login screen of your Deutsche Bank app</b>.",
+          "2": "On the back of your <b>Deutsche Bank card</b> (debit card).",
+          "3": "In the Deutsche Bank app: tap the menu icon (three lines) in the <b>top right > IBAN and BIC > Account (without the last two digits)</b>."
+        },
+        "listStyle": "disc",
+        "extra": "You can find your 7-digit account number in one of the following places:",
+        "extraStyle": "none",
+        "extraPosition": "top",
+        "button": "Done"
+      }
+    }
+  },
+  "666816b7941909eeadd917b3": {
+    "bankName": "C24",
+    "header": {
+      "mobileNumber": "Mobile number",
+      "pin": "PIN"
+    },
+    "step": {
+      "mobileNumber": {
+        "item": {
+          "1": "We hope you can find your personal phone number without our help."
+        },
+        "listStyle": "none",
+        "button": "Next"
+      },
+      "pin": {
+        "item": {
+          "1": "Your PIN is a four-digit number that you also use to <b>log in to your C24 app</b>.",
+          "2": "<b>Forgot your PIN?</b> You can change it in the C24 app by going to: Profile (icon in the top left) > Sicherheit & Datenschutz (Security & Privacy) > PIN ändern (Change PIN)."
+        },
+        "listStyle": "disc",
+        "button": "Done"
+      }
+    }
+  },
+  "65fb2564429176a59c86e97f": {
+    "bankName": "TARGOBANK",
+    "header": {
+      "userId": "User ID",
+      "password": "Password"
+    },
+    "step": {
+      "userId": {
+        "item": {
+          "1": "Your User ID is the same one you use to <b>log in to your online banking</b>.",
+          "2": "If you’ve <b>forgotten your User ID</b>, you can retrieve it here: <span>https://www.targobank.de/de/user/administration/UA_ForPassPriCusCurAcc.aspx</span>",
+          "3": "If you only have a credit card with TARGOBANK, use this link instead: <span>https://www.targobank.de/de/user/administration/UA_ForPassPriCusCreCar.aspx</span>"
+        },
+        "listStyle": "disc",
+        "button": "Next"
+      },
+      "password": {
+        "item": {
+          "1": "Use the same password you use to <b>log in to your online banking</b> in a browser.",
+          "2": "This is <u>not</u> your <i>easyTAN-Freigabecode</i>.",
+          "3": "<b>Forgot your password?</b> You can set a new one here: <span>https://www.targobank.de/de/user/administration/UA_ForPassPriCusCurAcc.aspx</span>",
+          "4": "If you only have a TARGOBANK credit card, use this link instead: <span>https://www.targobank.de/de/user/administration/UA_ForPassPriCusCreCar.aspx</span>"
+        },
+        "listStyle": "disc",
+        "button": "Done"
+      }
+    }
+  },
+  "65fb2564429176a59c86e9a0": {
+    "bankName": "DKB",
+    "header": {
+      "login": "Login Name",
+      "password": "Password"
+    },
+    "step": {
+      "login": {
+        "item": {
+          "1": "You can have your login name <b>sent to you by email here</b>: <span>https://banking.dkb.de/forgot-username</span>",
+          "2": "If you didn’t choose your login name yourself, it’s usually made up of the <b>last 10 digits of your IBAN</b> (=account number) <b>followed by a suffix</b> (typically _p or _c). For example: 1234567890_p.",
+          "3": "You can find your IBAN on the back of your debit card."
+        },
+        "listStyle": "disc",
+        "button": "Next"
+      },
+      "password": {
+        "item": {
+          "1": "Use your <b>online banking password</b>. This is the same password you use to log in to your online banking account via a browser or the DKB app.",
+          "2": "<b>Forgot your PIN?</b> You can set a new password in the DKB app by going to: Profile > App Settings > Change Password."
+        },
+        "listStyle": "disc",
+        "button": "Done"
+      }
+    }
+  }
+}

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -7,13 +7,22 @@ import type {
   BankFields,
   BankFieldsSchemaType,
   BankSchemaType,
+  BankTutorial,
 } from "./types";
+import deBankCredentialsTutorial from "./locales/de/bank-credentials-tutorial.json";
+import enBankCredentialsTutorial from "./locales/en/bank-credentials-tutorial.json";
+
+const BANK_CREDENTIALS_TUTORIAL = {
+  de: deBankCredentialsTutorial,
+  en: enBankCredentialsTutorial,
+} as const satisfies Record<string, Record<string, BankTutorial>>;
 
 export {
   BanksService,
   TOP_BANK_ORDER,
   BAD_VISIBILITY_LOGOS,
   NO_CREDENTIALS_BANKS,
+  BANK_CREDENTIALS_TUTORIAL,
   type Bank,
   type BankFields,
   type BankFieldsSchemaType,

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -54,3 +54,18 @@ export type BankFieldsSchemaType = {
   password_de?: string | undefined;
   password_en?: string | undefined;
 };
+
+type TutorialStep = {
+  item: Record<string, string>;
+  listStyle: string;
+  button: string;
+  extra?: string;
+  extraStyle?: string;
+  extraPosition?: string;
+};
+
+export type BankTutorial = {
+  bankName: string;
+  header: Record<string, string>;
+  step: Record<string, TutorialStep>;
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flizpay-de/banks",
   "private": false,
-  "version": "0.0.16",
+  "version": "0.0.24",
   "type": "module",
   "files": [
     "dist",


### PR DESCRIPTION
- Add two helper functions: `getBankCredentialsTutorial` and `bankHasCredentialsTutorial`;
- Added the necessary labels for the tutorials;
- Added the necessary types;
- Exported an object that contains the tutorials in both languages named `BANK_CREDENTIALS_TUTORIAL`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added in-app tutorials for retrieving or resetting bank login credentials for major German banks, available in both English and German.
  - Users can now access step-by-step, localized guidance to help find or recover their bank account credentials.

- **Documentation**
  - Included comprehensive, localized instructional content for supported banks to assist users with credential-related queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->